### PR TITLE
Fix items text wrapped around FontAwesome

### DIFF
--- a/src/ngx-tree-select/src/components/tree-select-item.component.html
+++ b/src/ngx-tree-select/src/components/tree-select-item.component.html
@@ -8,8 +8,8 @@
                 </span>
             <i class="fa" *ngIf="needCheckBox" [class.fa-check-square-o]="item.checked === true" [class.fa-square-o]="item.checked === false"
                 [class.fa-square]="item.checked === null" (click)="select($event)"></i>
-            <i class="fa" *ngIf="allowParentSelection" (click)="select($event)"> {{item.text}}</i>
-            <i class="fa" *ngIf="!allowParentSelection"> {{item.text}}</i>
+            <span *ngIf="allowParentSelection" (click)="select($event)"> {{item.text}}</span>
+            <span *ngIf="!allowParentSelection"> {{item.text}}</span>
         </a>
   </div>
   <ul *ngIf="haveChildren && isOpen" class="ui-select-choices" role="menu">


### PR DESCRIPTION
The items text in the dropdown gets wrapped around the `<i>` element with FontAwesome class. This override the font used to render item text with an "arial" like font. This should cleanly fix that!