### PR TITLE
Set ModuleWithProviders type (Angular 10+ support)

### DIFF
--- a/src/ngx-tree-select/package.json
+++ b/src/ngx-tree-select/package.json
@@ -9,8 +9,8 @@
     "select"
   ],
   "peerDependencies": {
-    "@angular/core": ">=4.0.0 <6.0.0",
-    "@angular/forms": ">=4.0.0 <6.0.0"
+    "@angular/core": ">=4.0.0 <^11.1.0",
+    "@angular/forms": ">=4.0.0 <^11.1.0"
   },
   "libConfig": {
     "inlineResources": true

--- a/src/ngx-tree-select/src/module.ts
+++ b/src/ngx-tree-select/src/module.ts
@@ -24,7 +24,7 @@ import { TreeSelectItemComponent } from './components/tree-select-item.component
 })
 
 export class NgxTreeSelectModule {
-  public static forRoot(options: TreeSelectDefaultOptions): ModuleWithProviders {
+  public static forRoot(options: TreeSelectDefaultOptions): ModuleWithProviders<NgxTreeSelectModule> {
     return {
       ngModule: NgxTreeSelectModule,
       providers: [


### PR DESCRIPTION
From Angular 10 onward, to set a type to the ModuleWithProviders is now mandatory. With this simple alteration, the library becomes Angular 10+ compatible.